### PR TITLE
Match x-heights

### DIFF
--- a/experiments/type_alphabet_weight_test-110117.py
+++ b/experiments/type_alphabet_weight_test-110117.py
@@ -1,5 +1,6 @@
 Variable([
     dict(name="customString", ui="TextEditor"),
+    dict(name="lockXHeight", ui="CheckBox"),
     dict(name="fontSize1", ui="Slider",
             args=dict(
                 value=83,
@@ -35,7 +36,7 @@ counter = 1
 
 
 ################# 😺 TRIPLES LETTERS IN YOUR STRING, THEN SETS THEM AS TEXT 😺 #################
-def testWeights(string):
+def testWeights(string, fontName1, fontName2, fontName3):
     counter = 1
     lineCount = 1
     textWidth = 0
@@ -51,15 +52,24 @@ def testWeights(string):
         if counter % 3 == 0:
             fill(fontColor3)
             fontSize(fontSize3)
-            font("Source Serif Pro Bold") ################# ✅ REPLACE WITH YOUR HIGH CONTRAST FONT ✅ #################
+            font(fontName3) ################# ✅ REPLACE WITH YOUR HIGH CONTRAST FONT ✅ #################
+
+            if lockXHeight:
+                fontSize(fontSize3 * calcRatio(fontName3, fontSize3))
+
+
         elif (counter + 1) % 3 ==0:
             fill(fontColor2)
             fontSize(fontSize2)
-            font("Source Serif Pro") ################# ✅ REPLACE WITH YOUR REGULAR CONTRAST FONT ✅ #################
+            font(fontName2) ################# ✅ REPLACE WITH YOUR REGULAR CONTRAST FONT ✅ #################
+
+            if lockXHeight:
+                fontSize(fontSize2 * calcRatio(fontName2, fontSize2))
+
         else:
             fill(fontColor1)
             fontSize(fontSize1)
-            font("Source Sans") ################# ✅ REPLACE WITH YOUR LOW CONTRAST FONT ✅ #################
+            font(fontName1) ################# ✅ REPLACE WITH YOUR LOW CONTRAST FONT ✅ #################
         
         text(char, (positionX, positionY))
         letterWidth, letterHeight = textSize(char)
@@ -80,16 +90,30 @@ def testWeights(string):
                 
         # to do: if letter doesn't exist in the supplied font, replace with "n" or some other user-defined string
 
+def calcRatio(targetFontName, targetFontSize):
+    # source font (font1)
+    fontSize(fontSize1)
+    font(fontName1)
+    xHeight1 = fontXHeight()
+    
+    # target font
+    fontSize(targetFontSize)
+    font(targetFontName)
+    xHeight2 = fontXHeight()
+
+    return xHeight1 / xHeight2
 
 ################# ✅ MAKE YOUR STRING HERE, THEN SET AS AN ARGUMENT IN FUNCTION CALL ✅ #################
 import string
 alpha = string.lowercase
 heylook = "testyerfonts"
 
+fontName1, fontName2, fontName3 = "Helvetica", "Vulf Mono", "Times New Roman"
+
 if customString != "":
-    testWeights(customString) # use your string as an argument
+    testWeights(customString, fontName1, fontName2, fontName3) # use your string as an argument
 else:
-    testWeights(alpha)
+    testWeights(alpha, fontName1, fontName2, fontName3)
 
 ################# 😺 SAVE AS A PDF IF YOU'D LIKE TO PRINT 😺 #################
 # saveImage("give-it-a-title.pdf")

--- a/experiments/type_alphabet_weight_test-110117.py
+++ b/experiments/type_alphabet_weight_test-110117.py
@@ -23,10 +23,6 @@ Variable([
 
 defaultFontColor1 = [.75,0,.75]
 
-print "font size 1 is " + str(fontSize1) + " pt"
-print "font size 2 is " + str(fontSize2) + " pt"
-print "font size 3 is " + str(fontSize3) + " pt"
-
 size('A3')
 
 fontSize(100)
@@ -55,8 +51,7 @@ def testWeights(string, fontName1, fontName2, fontName3):
             font(fontName3) ################# ✅ REPLACE WITH YOUR HIGH CONTRAST FONT ✅ #################
 
             if lockXHeight:
-                fontSize(fontSize3 * calcRatio(fontName3, fontSize3))
-
+                fontSize(newFontSize3)
 
         elif (counter + 1) % 3 ==0:
             fill(fontColor2)
@@ -64,7 +59,7 @@ def testWeights(string, fontName1, fontName2, fontName3):
             font(fontName2) ################# ✅ REPLACE WITH YOUR REGULAR CONTRAST FONT ✅ #################
 
             if lockXHeight:
-                fontSize(fontSize2 * calcRatio(fontName2, fontSize2))
+                fontSize(newFontSize2)
 
         else:
             fill(fontColor1)
@@ -90,7 +85,7 @@ def testWeights(string, fontName1, fontName2, fontName3):
                 
         # to do: if letter doesn't exist in the supplied font, replace with "n" or some other user-defined string
 
-def calcRatio(targetFontName, targetFontSize):
+def calcNewSize(targetFontName, targetFontSize):
     # source font (font1)
     fontSize(fontSize1)
     font(fontName1)
@@ -101,7 +96,7 @@ def calcRatio(targetFontName, targetFontSize):
     font(targetFontName)
     xHeight2 = fontXHeight()
 
-    return xHeight1 / xHeight2
+    return targetFontSize * (xHeight1 / xHeight2)
 
 ################# ✅ MAKE YOUR STRING HERE, THEN SET AS AN ARGUMENT IN FUNCTION CALL ✅ #################
 import string
@@ -110,10 +105,24 @@ heylook = "testyerfonts"
 
 fontName1, fontName2, fontName3 = "Helvetica", "Vulf Mono", "Times New Roman"
 
+print "font size 1 is " + str(fontSize1) + " pt"
+
+if lockXHeight:
+    newFontSize2 = calcNewSize(fontName2, fontSize2)
+    newFontSize3 = calcNewSize(fontName3, fontSize3)
+    
+    print "new font size 2 is %s pt" %newFontSize2
+    print "new font size 3 is %s pt" %newFontSize3
+
+else:
+    print "font size 2 is " + str(fontSize2) + " pt"
+    print "font size 3 is " + str(fontSize3) + " pt"
+
 if customString != "":
     testWeights(customString, fontName1, fontName2, fontName3) # use your string as an argument
 else:
     testWeights(alpha, fontName1, fontName2, fontName3)
+
 
 ################# 😺 SAVE AS A PDF IF YOU'D LIKE TO PRINT 😺 #################
 # saveImage("give-it-a-title.pdf")

--- a/experiments/type_alphabet_weight_test-110117.py
+++ b/experiments/type_alphabet_weight_test-110117.py
@@ -1,6 +1,6 @@
 Variable([
     dict(name="customString", ui="TextEditor"),
-    dict(name="lockXHeight", ui="CheckBox"),
+    dict(name="matchXHeights", ui="CheckBox"),
     dict(name="fontSize1", ui="Slider",
             args=dict(
                 value=83,
@@ -30,7 +30,6 @@ fallbackFont("Arial")
 
 counter = 1
 
-
 ################# 😺 TRIPLES LETTERS IN YOUR STRING, THEN SETS THEM AS TEXT 😺 #################
 def testWeights(string, fontName1, fontName2, fontName3):
     counter = 1
@@ -50,7 +49,7 @@ def testWeights(string, fontName1, fontName2, fontName3):
             fontSize(fontSize3)
             font(fontName3) ################# ✅ REPLACE WITH YOUR HIGH CONTRAST FONT ✅ #################
 
-            if lockXHeight:
+            if matchXHeights:
                 fontSize(newFontSize3)
 
         elif (counter + 1) % 3 ==0:
@@ -58,7 +57,7 @@ def testWeights(string, fontName1, fontName2, fontName3):
             fontSize(fontSize2)
             font(fontName2) ################# ✅ REPLACE WITH YOUR REGULAR CONTRAST FONT ✅ #################
 
-            if lockXHeight:
+            if matchXHeights:
                 fontSize(newFontSize2)
 
         else:
@@ -107,10 +106,10 @@ fontName1, fontName2, fontName3 = "Helvetica", "Vulf Mono", "Times New Roman"
 
 print "font size 1 is " + str(fontSize1) + " pt"
 
-if lockXHeight:
+if matchXHeights:
     newFontSize2 = calcNewSize(fontName2, fontSize2)
     newFontSize3 = calcNewSize(fontName3, fontSize3)
-    
+
     print "new font size 2 is %s pt" %newFontSize2
     print "new font size 3 is %s pt" %newFontSize3
 


### PR DESCRIPTION
Hey! Just testing some stuff here... Sorry for intruding—been wanting to try something like this for a while (so I can set multiple typefaces in a line without eyeballing too much)!

The lockXHeight checkbox runs a function that grabs x-height info from the open fonts, calculates the x-height to font size ratio, and returns new sizes for font2 and font3. Currently fontSize1 is the master.

I also moved some stuff around so fonts are defined in one place, and so those names can be passed around as arguments. (I did this mainly because for DB to grab x-height info, the font name and size have to be declared first... but I might be wrong, or there might be a smarter way of doing this.) I moved the print statements to the bottom so I can see the new point sizes (and use them in Indd, etc.).

A web version would be amazing! Setting inline stuff with matching x-heights can be a pain sometimes...